### PR TITLE
Iso8583 v1.3.5

### DIFF
--- a/ISO8583/ISO8583.py
+++ b/ISO8583/ISO8583.py
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 __author__ = 'Igor Vitorio Custodio <igorvc@vulcanno.com.br>'
-__version__ = '1.3.4'
+__version__ = '1.3.5'
 __licence__ = 'GPL V3'
 
 import sys

--- a/ISO8583/ISO8583.py
+++ b/ISO8583/ISO8583.py
@@ -1080,7 +1080,7 @@ class ISO8583:
                         self.__raiseValueTypeError(cont)
 
                     if bitType == 'AN' and not value.isalnum():
-                        self.__raiseValueTypeError(bit)
+                        self.__raiseValueTypeError(cont)
 
 
                     self.BITMAP_VALUES[cont] = value


### PR DESCRIPTION
Added support for byte encoding on python3 in the getNetworkISO method since it is not automatically converted from bytes to ascii or unicode strings. 

Added function to raise an InvalidValueType exception, used to avoid repeating code.
Added verification on type for the bit setting methods, on iso creation and on usage of setBit method. Bit type verification only for types A, N, ANS.