### PR TITLE
Fixed 2 example modules to work in Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,14 +16,17 @@ downloads/
 eggs/
 .eggs/
 lib/
-lib64/
+lib64
 parts/
 sdist/
 var/
 wheels/
+bin/
+share/
 *.egg-info/
 .installed.cfg
 *.egg
+pyvenv.cfg
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/ISO8583/ISO8583.py
+++ b/ISO8583/ISO8583.py
@@ -1737,8 +1737,8 @@ class ISO8583:
                 _TMP = {}
                 _TMP['bit'] = "%d" % cont
                 _TMP['type'] = self.getBitType(cont)
-                _TMP['value(raw)'] = self.BITMAP_VALUES[cont]
-                _TMP['value(decoded)'] = self.getBit(cont)
+                _TMP['value_raw'] = self.BITMAP_VALUES[cont]
+                _TMP['value'] = self.getBit(cont)
                 ret.append(_TMP)
         return ret
 

--- a/examples/echoClient.py
+++ b/examples/echoClient.py
@@ -19,101 +19,103 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 from ISO8583.ISO8583 import ISO8583
-from ISO8583.ISOErrors import *
+from ISO8583.ISOErrors import InvalidIso8583
 import socket
 import sys
 import time
 
 
 # Configure the client
-serverIP = "192.168.0.103" 
+serverIP = "localhost"
 serverPort = 8583
 numberEcho = 5
-timeBetweenEcho = 5 # in seconds
+timeBetweenEcho = 5  # in seconds
 
 bigEndian = True
-#bigEndian = False
+# bigEndian = False
 
 s = None
-for res in socket.getaddrinfo(serverIP, serverPort, socket.AF_UNSPEC, socket.SOCK_STREAM):
+
+for res in socket.getaddrinfo(
+        serverIP, serverPort, socket.AF_UNSPEC, socket.SOCK_STREAM):
     af, socktype, proto, canonname, sa = res
     try:
-		s = socket.socket(af, socktype, proto)
-    except socket.error, msg:
-	s = None
-	continue
+        s = socket.socket(af, socktype, proto)
+    except socket.error:
+        s = None
+        continue
     try:
-		s.connect(sa)
-    except socket.error, msg:
-	s.close()
-	s = None
-	continue
-    break
+        s.connect(sa)
+    except socket.error:
+        s.close()
+        s = None
+        continue
+        break
+
 if s is None:
     print ('Could not connect :(')
     sys.exit(1)
-	
-	
-	
-for req in range(0,numberEcho):
-	iso = ISO8583()
-	iso.setMTI('0800')
-	iso.setBit(3,'300000')	
-	iso.setBit(24,'045')	
-	iso.setBit(41,'11111111')	
-	iso.setBit(42,'222222222222222')	
-	iso.setBit(63,'This is a Test Message')
-	if bigEndian:
-		try:
-			message = iso.getNetworkISO() 
-			s.send(message)
-			print ('Sending ... %s' % message)
-			ans = s.recv(2048)
-			print ("\nInput ASCII |%s|" % ans)
-			isoAns = ISO8583()
-			isoAns.setNetworkISO(ans)
-			v1 = isoAns.getBitsAndValues()
-			for v in v1:
-				print ('Bit %s of type %s with value = %s' % (v['bit'],v['type'],v['value']))
-				
-			if isoAns.getMTI() == '0810':
-				print ("\tThat's great !!! The server understand my message !!!")
-			else:
-				print ("The server dosen't understand my message!")
-					
-		except InvalidIso8583, ii:
-			print ii
-			break	
-		
 
-		time.sleep(timeBetweenEcho)
-		
-	else:
-		try:
-			message = iso.getNetworkISO(False) 
-			s.send(message)
-			print ('Sending ... %s' % message)
-			ans = s.recv(2048)
-			print ("\nInput ASCII |%s|" % ans)
-			isoAns = ISO8583()
-			isoAns.setNetworkISO(ans,False)
-			v1 = isoAns.getBitsAndValues()
-			for v in v1:
-				print ('Bit %s of type %s with value = %s' % (v['bit'],v['type'],v['value']))
-					
-			if isoAns.getMTI() == '0810':
-				print ("\tThat's great !!! The server understand my message !!!")
-			else:
-				print ("The server dosen't understand my message!")
-			
-		except InvalidIso8583, ii:
-			print ii
-			break	
-		
-		time.sleep(timeBetweenEcho)
 
-		
-		
-print ('Closing...')		
-s.close()		
-		
+for req in range(0, numberEcho):
+    iso = ISO8583()
+    iso.setMTI('0800')
+    iso.setBit(3, '300000')
+    iso.setBit(24, '045')
+    iso.setBit(41, '11111111')
+    iso.setBit(42, '222222222222222')
+    iso.setBit(63, 'This is a Test Message')
+    if bigEndian:
+        try:
+            message = iso.getNetworkISO()
+            s.send(message)
+            print ('Sending ... %s' % message)
+            ans = s.recv(2048)
+            print ("\nInput ASCII |%s|" % ans)
+            isoAns = ISO8583()
+            isoAns.setNetworkISO(ans)
+            v1 = isoAns.getBitsAndValues()
+            for v in v1:
+                print (
+                    'Bit %s of type %s with value = %r, value_raw = %r)' %
+                    (v['bit'], v['type'], v['value'], v['value_raw']))
+
+            if isoAns.getMTI() == '0810':
+                print ("\tThe server understands my message !!!")
+            else:
+                print ("The server doesn't understand my message!")
+
+        except InvalidIso8583 as ii:
+            print (ii)
+            break
+
+        time.sleep(timeBetweenEcho)
+
+    else:
+        try:
+            message = iso.getNetworkISO(False)
+            s.send(message)
+            print ('Sending ... %s' % message)
+            ans = s.recv(2048)
+            print ("\nInput ASCII |%s|" % ans)
+            isoAns = ISO8583()
+            isoAns.setNetworkISO(ans, False)
+            v1 = isoAns.getBitsAndValues()
+            for v in v1:
+                print (
+                    'Bit %s of type %s with value = %r, value_raw = %r' %
+                    (v['bit'], v['type'], v['value'], v['value_raw']))
+
+            if isoAns.getMTI() == '0810':
+                print ("\tThe server understand my message !!!")
+            else:
+                print ("The server dosen't understand my message!")
+
+        except InvalidIso8583 as ii:
+            print (ii)
+            break
+
+        time.sleep(timeBetweenEcho)
+
+print ('Closing...')
+s.close()

--- a/examples/echoServer.py
+++ b/examples/echoServer.py
@@ -19,73 +19,74 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 from ISO8583.ISO8583 import ISO8583
-from ISO8583.ISOErrors import *
-from socket import *
+from ISO8583.ISOErrors import InvalidIso8583
+import socket
 
 # Configure the server
-serverIP = "192.168.0.103" 
+serverIP = "localhost"
 serverPort = 8583
 maxConn = 5
 bigEndian = True
-#bigEndian = False
+# bigEndian = False
 
 
 # Create a TCP socket
-s = socket(AF_INET, SOCK_STREAM)    
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 # bind it to the server port
-s.bind((serverIP, serverPort))   
+s.bind((serverIP, serverPort))
 # Configure it to accept up to N simultaneous Clients waiting...
-s.listen(maxConn)                        
+s.listen(maxConn)
 
 
 # Run forever
 while 1:
-	#wait new Client Connection
-	connection, address = s.accept() 
-	while 1:
-		# receive message
-		isoStr = connection.recv(2048) 
-		if isoStr:
-			print ("\nInput ASCII |%s|" % isoStr)
-			pack = ISO8583()
-			#parse the iso
-			try:
-				if bigEndian:
-					pack.setNetworkISO(isoStr)
-				else:
-					pack.setNetworkISO(isoStr,False)
-			
-				v1 = pack.getBitsAndValues()
-				for v in v1:
-					print ('Bit %s of type %s with value = %s' % (v['bit'],v['type'],v['value']))
-					
-				if pack.getMTI() == '0800':
-					print ("\tThat's great !!! The client send a correct message !!!")
-				else:
-					print ("The client dosen't send the correct message!")	
-					break
-					
-					
-			except InvalidIso8583, ii:
-				print ii
-				break
-			except:
-				print ('Something happened!!!!')
-				break
-			
-			#send answer
-			pack.setMTI('0810')
-			
-			if bigEndian:
-				ans = pack.getNetworkISO()
-			else:
-				ans = pack.getNetworkISO(False)
-				
-			print ('Sending answer %s' % ans)
-			connection.send(ans)
-			
-		else:
-			break
-	# close socket		
-	connection.close()             
-	print ("Closed...")
+    print("Waiting for a connection to %s:%s." % (serverIP, serverPort))
+    # wait new Client Connection
+    connection, address = s.accept()
+    while 1:
+        # receive message
+        isoStr = connection.recv(2048)
+        if isoStr:
+            print ("\nInput ASCII |%s|" % isoStr)
+            pack = ISO8583()
+            # parse the iso
+            try:
+                if bigEndian:
+                    pack.setNetworkISO(isoStr)
+                else:
+                    pack.setNetworkISO(isoStr, False)
+
+                v1 = pack.getBitsAndValues()
+                for v in v1:
+                    print (
+                        'Bit %s of type %s with value = %r, value_raw = %r'
+                        % (v['bit'], v['type'], v['value'], v['value_raw'])
+                    )
+
+                if pack.getMTI() == '0800':
+                    print ("\tThe client sent a correct message !!!")
+                else:
+                    print ("The client didn't send the correct message!")
+                    break
+
+            except InvalidIso8583 as ii:
+                print (ii)
+                break
+
+            # send answer
+            pack.setMTI('0810')
+
+            if bigEndian:
+                ans = pack.getNetworkISO()
+            else:
+                ans = pack.getNetworkISO(False)
+
+            print ('Sending answer %s' % ans)
+            connection.send(ans)
+
+        else:
+            break
+
+    # close socket
+    connection.close()
+    print ("Closed...")


### PR DESCRIPTION
This pull request makes the echoClient and echoServer example modules work in Python 3. Among other things, this involved converting tabs to spaces because Python 3 is more sensitive about tabs.